### PR TITLE
Feat GitHub oauth login

### DIFF
--- a/wtnt/core/middleware.py
+++ b/wtnt/core/middleware.py
@@ -4,35 +4,45 @@ from django.utils.deprecation import MiddlewareMixin
 class AttachJWTFromHeaderToCookieMiddleware(MiddlewareMixin):
     def __init__(self, get_response):
         super().__init__(get_response)
-        self.APIS = ['github/login', 'github/finish', 'token/refresh']
-    
+        self.APIS = ["github/login", "github/finish"]
+        self.REFRESH = "token/refresh"
+
     def process_response(self, request, response):
         path = request.path_info
         is_valid = any(api in path for api in self.APIS)
+        is_refresh = True if self.REFRESH in path else False
 
-        if is_valid:
-            if request.META.get('HTTP_FROM', None) == 'web':
-                response.set_cookie('refresh', response.data['refresh'])
-                response.set_cookie('access', response.data['access'])
-                
-                response.data.pop('access')
-                response.data.pop('refresh')
+        if is_valid or is_refresh:
+            if request.META.get("HTTP_FROM", None) == "web":
+                print(response.data)
+                response.set_cookie("refresh", response["refresh"])
+                response.set_cookie("access", response["access"])
+
+                if is_valid:
+                    response.data.pop("access")
+                    response.data.pop("refresh")
 
                 response.content = response.render().rendered_content
-        
+
         return response
 
 
 class AttachJWTFromCookieToHeaderMiddleware(MiddlewareMixin):
     def __init__(self, get_response):
         super().__init__(get_response)
-        self.NOT_APIS = ['github/login', 'github/finish', 'token/refresh']
+        self.NOT_APIS = ["github/login", "github/finish"]
+        self.REFRESH = "token/refresh"
 
     def process_request(self, request):
         path = request.path_info
         is_valid = any(api in path for api in self.NOT_APIS)
+        is_refresh = True if self.REFRESH in path else False
 
-        if is_valid:
-            if request.META.get('HTTP_FROM', None) == 'web':
-                request.META['access'] = request.COOKIES.get('access', None)
-                request.META['refresh'] = request.COOKIES.get('refresh', None)
+        if not is_valid:
+            if request.META.get("HTTP_FROM", None) == "web":
+                request.META["access"] = request.COOKIES.get("access", None)
+                request.META["refresh"] = request.COOKIES.get("refresh", None)
+
+        if is_refresh:
+            if request.META.get("HTTP_FROM", None) == "web":
+                request.META["refresh"] = request.COOKIES.get("refresh", None)

--- a/wtnt/core/middleware.py
+++ b/wtnt/core/middleware.py
@@ -1,4 +1,5 @@
 from django.utils.deprecation import MiddlewareMixin
+from rest_framework import status
 
 
 class AttachJWTFromHeaderToCookieMiddleware(MiddlewareMixin):
@@ -12,9 +13,12 @@ class AttachJWTFromHeaderToCookieMiddleware(MiddlewareMixin):
         is_valid = any(api in path for api in self.APIS)
         is_refresh = True if self.REFRESH in path else False
 
-        if is_valid or is_refresh:
+        if (
+            is_valid
+            or is_refresh
+            and (response.status_code == status.HTTP_200_OK or response.status_code == status.HTTP_201_CREATED)
+        ):
             if request.META.get("HTTP_FROM", None) == "web":
-                print(response.data)
                 response.set_cookie("refresh", response["refresh"])
                 response.set_cookie("access", response["access"])
 

--- a/wtnt/core/middleware.py
+++ b/wtnt/core/middleware.py
@@ -1,0 +1,23 @@
+from django.utils.deprecation import MiddlewareMixin
+
+
+class AttachJWTFromHeaderToCookieMiddleware(MiddlewareMixin):
+    def __init__(self, get_response):
+        super().__init__(get_response)
+        self.APIS = ['github/login', 'github/finish', 'token/refresh']
+    
+    def process_response(self, request, response):
+        path = request.path_info
+        is_valid = any(api in path for api in self.APIS)
+
+        if is_valid:
+            if request.META.get('HTTP_FROM', None) == 'web':
+                response.set_cookie('refresh', response.data['refresh'])
+                response.set_cookie('access', response.data['access'])
+                
+                response.data.pop('access')
+                response.data.pop('refresh')
+
+                response.content = response.render().rendered_content
+        
+        return response

--- a/wtnt/core/middleware.py
+++ b/wtnt/core/middleware.py
@@ -21,3 +21,18 @@ class AttachJWTFromHeaderToCookieMiddleware(MiddlewareMixin):
                 response.content = response.render().rendered_content
         
         return response
+
+
+class AttachJWTFromCookieToHeaderMiddleware(MiddlewareMixin):
+    def __init__(self, get_response):
+        super().__init__(get_response)
+        self.NOT_APIS = ['github/login', 'github/finish', 'token/refresh']
+
+    def process_request(self, request):
+        path = request.path_info
+        is_valid = any(api in path for api in self.NOT_APIS)
+
+        if is_valid:
+            if request.META.get('HTTP_FROM', None) == 'web':
+                request.META['access'] = request.COOKIES.get('access', None)
+                request.META['refresh'] = request.COOKIES.get('refresh', None)

--- a/wtnt/user/auth/urls.py
+++ b/wtnt/user/auth/urls.py
@@ -1,8 +1,9 @@
 from django.urls import path
-from .views import GithubLoginView, GithubOAuthCallBackView, FinishGithubLoginView
+from .views import GithubLoginView, GithubOAuthCallBackView, FinishGithubLoginView, WtntTokenRefreshView
 
 urlpatterns = [
     path("github/callback", GithubOAuthCallBackView.as_view()),
     path("github/login", GithubLoginView.as_view()),
     path("github/finish", FinishGithubLoginView.as_view()),
+    path("token/refresh", WtntTokenRefreshView.as_view()),
 ]

--- a/wtnt/user/auth/urls.py
+++ b/wtnt/user/auth/urls.py
@@ -1,0 +1,8 @@
+from django.urls import path
+from .views import GithubLoginView, GithubOAuthCallBackView, FinishGithubLoginView
+
+urlpatterns = [
+    path("github/callback", GithubOAuthCallBackView.as_view()),
+    path("github/login", GithubLoginView.as_view()),
+    path("github/finish", FinishGithubLoginView.as_view()),
+]

--- a/wtnt/user/auth/views.py
+++ b/wtnt/user/auth/views.py
@@ -5,7 +5,6 @@ from rest_framework.views import APIView
 from rest_framework.request import Request
 from rest_framework.response import Response
 from rest_framework import status
-from rest_framework_simplejwt.tokens import AccessToken
 from dj_rest_auth.registration.views import SocialLoginView
 from django.contrib.auth import get_user_model
 
@@ -16,17 +15,18 @@ import json
 
 User = get_user_model()
 
+
 class GithubLoginView(SocialLoginView):
     adapter_class = GitHubOAuth2Adapter
-    callback_url = "http://localhost:8000/api/user/github/callback"
+    callback_url = "http://localhost:8000/api/auth/github/callback"
     client_class = OAuth2Client
 
     def post(self, request, *args, **kwargs):
         response = super().post(request, *args, **kwargs)
         response_data = response.data
-        
+
         if response_data["user"]["email"]:
-            response_data["registered"] = True   
+            response_data["registered"] = True
         else:
             response_data["registered"] = False
 
@@ -43,9 +43,9 @@ class GithubOAuthCallBackView(APIView):
                 {"error": "Failed to process with GithubLoginView"},
                 status=response.status_code,
             )
-        
+
     def send_code_to_github_login_view(self, code: str):
-        url = "http://localhost:8000/api/user/github/login"
+        url = "http://localhost:8000/api/auth/github/login"
         payload = {"code": code}
         headers = {"Content-Type": "application/json"}
         response = requests.post(url, json=payload, headers=headers)
@@ -59,7 +59,7 @@ class FinishGithubLoginView(APIView):
 
         user_id = request_data["user_id"]
         extra_data = SocialAccount.objects.get(user_id=user_id).extra_data
-    
+
         user = User.objects.get(id=user_id)
         user.student_num = str(request_data.get("student_num"))
         user.name = request_data.get("name")

--- a/wtnt/user/models.py
+++ b/wtnt/user/models.py
@@ -9,7 +9,7 @@ from core.models import TimestampedModel
 
 class CustomUser(AbstractBaseUser, PermissionsMixin, TimestampedModel):
     email = models.EmailField(unique=True)
-    social_id = models.IntegerField()
+    social_id = models.IntegerField(null=True)
     name = models.CharField(max_length=5)
     university = models.CharField(max_length=8, null=True)
     club = models.CharField(max_length=10, null=True)

--- a/wtnt/user/models.py
+++ b/wtnt/user/models.py
@@ -9,12 +9,13 @@ from core.models import TimestampedModel
 
 class CustomUser(AbstractBaseUser, PermissionsMixin, TimestampedModel):
     email = models.EmailField(unique=True)
+    social_id = models.IntegerField()
     name = models.CharField(max_length=5)
     university = models.CharField(max_length=8, null=True)
     club = models.CharField(max_length=10, null=True)
     student_num = models.CharField(max_length=20, null=True)
     tech = models.CharField(max_length=200, null=True)
-    image = models.CharField(max_length=50, null=True)
+    image = models.CharField(max_length=200, null=True)
     is_apporoved = models.BooleanField(default=False)
     is_active = models.BooleanField(default=True)
     is_staff = models.BooleanField(default=False)

--- a/wtnt/user/urls.py
+++ b/wtnt/user/urls.py
@@ -1,7 +1,8 @@
 from django.urls import path
-from .views import GithubLoginView, GithubOAuthCallBackView
+from .views import GithubLoginView, GithubOAuthCallBackView, FinishGithubLoginView
 
 urlpatterns = [
     path("github/callback", GithubOAuthCallBackView.as_view()),
     path("github/login", GithubLoginView.as_view()),
+    path("github/finish", FinishGithubLoginView.as_view()),
 ]

--- a/wtnt/user/urls.py
+++ b/wtnt/user/urls.py
@@ -1,8 +1,3 @@
-from django.urls import path
-from .views import GithubLoginView, GithubOAuthCallBackView, FinishGithubLoginView
+from django.urls import path, include
 
-urlpatterns = [
-    path("github/callback", GithubOAuthCallBackView.as_view()),
-    path("github/login", GithubLoginView.as_view()),
-    path("github/finish", FinishGithubLoginView.as_view()),
-]
+urlpatterns = [path("auth/", include("user.auth.urls"))]

--- a/wtnt/user/urls.py
+++ b/wtnt/user/urls.py
@@ -1,0 +1,7 @@
+from django.urls import path
+from .views import GithubLoginView, GithubOAuthCallBackView
+
+urlpatterns = [
+    path("github/callback", GithubOAuthCallBackView.as_view()),
+    path("github/login", GithubLoginView.as_view()),
+]

--- a/wtnt/user/views.py
+++ b/wtnt/user/views.py
@@ -25,20 +25,10 @@ class GithubLoginView(SocialLoginView):
         response = super().post(request, *args, **kwargs)
         response_data = response.data
         
-        if not response_data["user"]["email"]:
-            request_data = json.loads(request.body)
-
-            user_id = response_data["user"]["pk"]
-            extra_data = SocialAccount.objects.get(user_id=user_id).extra_data
-        
-            user = User.objects.get(id=user_id)
-            user.student_num = str(request_data.get("student_num"))
-            user.name = request_data.get("name")
-            user.email = extra_data.get("login") + "@github.com"
-            user.image = extra_data.get("avatar_url")
-            user.save()
-
-            return Response(response_data, status=status.HTTP_201_CREATED)
+        if response_data["user"]["email"]:
+            response_data["registered"] = True   
+        else:
+            response_data["registered"] = False
 
         return Response(response_data, status=status.HTTP_200_OK)
 
@@ -61,3 +51,21 @@ class GithubOAuthCallBackView(APIView):
         response = requests.post(url, json=payload, headers=headers)
 
         return response
+
+
+class FinishGithubLoginView(APIView):
+    def post(self, request):
+        request_data = json.loads(request.body)
+
+        user_id = request_data["user_id"]
+        extra_data = SocialAccount.objects.get(user_id=user_id).extra_data
+    
+        user = User.objects.get(id=user_id)
+        user.student_num = str(request_data.get("student_num"))
+        user.name = request_data.get("name")
+        user.email = extra_data.get("login") + "@github.com"
+        user.image = extra_data.get("avatar_url")
+
+        user.save()
+
+        return Response({"success": True}, status=status.HTTP_201_CREATED)

--- a/wtnt/user/views.py
+++ b/wtnt/user/views.py
@@ -1,3 +1,63 @@
-# from django.shortcuts import render
+from allauth.socialaccount.models import SocialAccount
+from allauth.socialaccount.providers.github.views import GitHubOAuth2Adapter
+from allauth.socialaccount.providers.oauth2.client import OAuth2Client
+from rest_framework.views import APIView
+from rest_framework.request import Request
+from rest_framework.response import Response
+from rest_framework import status
+from rest_framework_simplejwt.tokens import AccessToken
+from dj_rest_auth.registration.views import SocialLoginView
+from django.contrib.auth import get_user_model
+
+import requests
+import json
 
 # Create your views here.
+
+User = get_user_model()
+
+class GithubLoginView(SocialLoginView):
+    adapter_class = GitHubOAuth2Adapter
+    callback_url = "http://localhost:8000/api/user/github/callback"
+    client_class = OAuth2Client
+
+    def post(self, request, *args, **kwargs):
+        response = super().post(request, *args, **kwargs)
+        response_data = response.data
+        
+        if not response_data["user"]["email"]:
+            request_data = json.loads(request.body)
+
+            user_id = response_data["user"]["pk"]
+            extra_data = SocialAccount.objects.get(user_id=user_id).extra_data
+        
+            user = User.objects.get(id=user_id)
+            user.student_num = str(request_data.get("student_num"))
+            user.name = request_data.get("name")
+            user.email = extra_data.get("login") + "@github.com"
+            user.image = extra_data.get("avatar_url")
+            user.save()
+
+            return Response(response_data, status=status.HTTP_201_CREATED)
+
+        return Response(response_data, status=status.HTTP_200_OK)
+
+
+class GithubOAuthCallBackView(APIView):
+    def get(self, request: Request):
+        if code := request.GET.get("code"):
+            response = self.send_code_to_github_login_view(code)
+            if response.status_code == 200:
+                return Response(response.json(), status=status.HTTP_200_OK)
+            return Response(
+                {"error": "Failed to process with GithubLoginView"},
+                status=response.status_code,
+            )
+        
+    def send_code_to_github_login_view(self, code: str):
+        url = "http://localhost:8000/api/user/github/login"
+        payload = {"code": code}
+        headers = {"Content-Type": "application/json"}
+        response = requests.post(url, json=payload, headers=headers)
+
+        return response

--- a/wtnt/wtnt/settings.py
+++ b/wtnt/wtnt/settings.py
@@ -11,6 +11,7 @@ https://docs.djangoproject.com/en/5.0/ref/settings/
 """
 import environ
 import os
+from datetime import timedelta
 from pathlib import Path
 
 # Build paths inside the project like this: BASE_DIR / 'subdir'.
@@ -28,11 +29,52 @@ SECRET_KEY = env("SECRET_KEY")
 # SECURITY WARNING: don't run with debug turned on in production!
 DEBUG = True
 
+SITE_ID = 1
+
 ALLOWED_HOSTS = []
 
 AUTH_USER_MODEL = "user.CustomUser"
 
-REST_USE_JWT = True
+REST_AUTH = {
+    "TOKEN_MODEL": None,
+    "USE_JWT": True,
+    "JWT_AUTH_COOKIE": "access_token",
+    'JWT_AUTH_REFRESH_COOKIE': "refresh_token",
+    "JWT_AUTH_HTTPONLY": False,
+    "SESSION_LOGIN": False,
+}
+
+
+SIMPLE_JWT = {
+    "ACCESS_TOKEN_LIFETIME": timedelta(minutes=30),
+    "REFRESH_TOKEN_LIFETIME": timedelta(days=7),
+    "ROTATE_REFRESH_TOKENS": True,
+    "UPDATE_LAST_LOGIN": True,
+    "ALGORITHM": "HS256",
+    "SIGNING_KEY": SECRET_KEY,
+    "VERIFYING_KEY": None,
+    "AUDIENCE": None,
+    "ISSUER": None,
+    "JWK_URL": None,
+    "LEEWAY": 0,
+    "AUTH_HEADER_TYPES": ("Bearer",),
+    "AUTH_HEADER_NAME": "HTTP_AUTHORIZATION",
+    "USER_ID_FIELD": "id",
+    "USER_ID_CLAIM": "user_id",
+    "USER_AUTHENTICATION_RULE": "rest_framework_simplejwt.authentication.default_user_authentication_rule",
+    "AUTH_TOKEN_CLASSES": ("rest_framework_simplejwt.tokens.AccessToken",),
+    "TOKEN_TYPE_CLAIM": "token_type",
+    "TOKEN_USER_CLASS": "rest_framework_simplejwt.models.TokenUser",
+    "JTI_CLAIM": "jti",
+}
+
+
+REST_FRAMEWORK = {
+    "DEFAULT_AUTHENTICATION_CLASSES": (
+        "rest_framework_simplejwt.authentication.JWTAuthentication",
+    ),
+}
+
 
 ACCOUNT_USERNAME_REQUIRED = False
 ACCOUNT_USER_MODEL_USERNAME_FIELD = None
@@ -49,9 +91,17 @@ INSTALLED_APPS = [
     "django.contrib.sessions",
     "django.contrib.messages",
     "django.contrib.staticfiles",
+    "django.contrib.sites",
     "rest_framework",
+    "rest_framework_simplejwt",
     "user",
     "team",
+    "allauth",
+    "allauth.account",
+    "allauth.socialaccount",
+    "allauth.socialaccount.providers.github",
+    "dj_rest_auth",
+    "dj_rest_auth.registration",
 ]
 
 MIDDLEWARE = [
@@ -62,6 +112,7 @@ MIDDLEWARE = [
     "django.contrib.auth.middleware.AuthenticationMiddleware",
     "django.contrib.messages.middleware.MessageMiddleware",
     "django.middleware.clickjacking.XFrameOptionsMiddleware",
+    "allauth.account.middleware.AccountMiddleware",
 ]
 
 ROOT_URLCONF = "wtnt.urls"

--- a/wtnt/wtnt/settings.py
+++ b/wtnt/wtnt/settings.py
@@ -61,7 +61,6 @@ SIMPLE_JWT = {
     "AUTH_HEADER_NAME": "HTTP_AUTHORIZATION",
     "USER_ID_FIELD": "id",
     "USER_ID_CLAIM": "user_id",
-    "USER_AUTHENTICATION_RULE": "rest_framework_simplejwt.authentication.default_user_authentication_rule",
     "AUTH_TOKEN_CLASSES": ("rest_framework_simplejwt.tokens.AccessToken",),
     "TOKEN_TYPE_CLAIM": "token_type",
     "TOKEN_USER_CLASS": "rest_framework_simplejwt.models.TokenUser",

--- a/wtnt/wtnt/settings.py
+++ b/wtnt/wtnt/settings.py
@@ -104,6 +104,7 @@ INSTALLED_APPS = [
 ]
 
 MIDDLEWARE = [
+    "core.middleware.AttachJWTFromCookieToHeaderMiddleware",
     "django.middleware.security.SecurityMiddleware",
     "django.contrib.sessions.middleware.SessionMiddleware",
     "django.middleware.common.CommonMiddleware",
@@ -112,6 +113,7 @@ MIDDLEWARE = [
     "django.contrib.messages.middleware.MessageMiddleware",
     "django.middleware.clickjacking.XFrameOptionsMiddleware",
     "allauth.account.middleware.AccountMiddleware",
+    "core.middleware.AttachJWTFromHeaderToCookieMiddleware",
 ]
 
 ROOT_URLCONF = "wtnt.urls"

--- a/wtnt/wtnt/urls.py
+++ b/wtnt/wtnt/urls.py
@@ -19,6 +19,6 @@ from django.urls import path, include
 
 urlpatterns = [
     path("", include("allauth.urls")),
-    path("api/user/", include('user.urls')),
+    path("api/", include("user.urls")),
     path("admin/", admin.site.urls),
 ]

--- a/wtnt/wtnt/urls.py
+++ b/wtnt/wtnt/urls.py
@@ -18,7 +18,7 @@ from django.contrib import admin
 from django.urls import path, include
 
 urlpatterns = [
-    # path("", include("allauth.urls")),
+    path("", include("allauth.urls")),
     path("api/user/", include('user.urls')),
     path("admin/", admin.site.urls),
 ]

--- a/wtnt/wtnt/urls.py
+++ b/wtnt/wtnt/urls.py
@@ -15,8 +15,10 @@ Including another URLconf
     2. Add a URL to urlpatterns:  path('blog/', include('blog.urls'))
 """
 from django.contrib import admin
-from django.urls import path
+from django.urls import path, include
 
 urlpatterns = [
+    # path("", include("allauth.urls")),
+    path("api/user/", include('user.urls')),
     path("admin/", admin.site.urls),
 ]


### PR DESCRIPTION
**## #️⃣ 연관된 이슈** 
> ex) #이슈번호
 <!-- PR Merge 후 이슈 Closed로 바꾸기 -->
- #7 
 
---

**## 📝 작업 내용**
> ex) 소셜 로그인 연동
- 깃허브 소셜 로그인
- 회원가입 시 학번, 실명 추가로 입력받게 작성
- 리프레쉬 토큰으로 access_token, refresh_token 갱신 가능

---

**## 📢 참고사항**
> ex) Issue 내용과 달라진 점
- RedirectUrl을 프론트, 앱과 연동 시에 변경해야함.
- 추후에 쿠키 설정하는 부분에서 secure=True, httponly=True 등 설정해야함.
- 로그아웃은 프론트, 앱 측에서 토큰 값을 제거하는 것으로 동작하는 것으로 생각 중.
- 현재 토큰 리프레싱하는 과정에서 불필요하게 리프레시 토큰까지 갱신해주는 것으로 보이므로 액세스토큰만 갱신하게 수정해야할 수도 있음.