### PR TITLE
[FEAT] 유저/팀 삭제 후 캐시 관리

### DIFF
--- a/wtnt/admin/team/service.py
+++ b/wtnt/admin/team/service.py
@@ -42,6 +42,7 @@ class AdminTeamService(BaseService, TeamListPagenationSize10):
         if status:
             for team in teams:
                 S3Utils.delete_team_image_on_s3(team.uuid)
+            cache.delete_many([f"team_detail_{team.id}" for team in teams])
         cnt, _ = teams.delete()
         if cnt:
             return {"detail": "Success to reject teams"}

--- a/wtnt/admin/user/service.py
+++ b/wtnt/admin/user/service.py
@@ -37,6 +37,7 @@ class AdminUserService(BaseService, UserListPagenationSize10):
         if status:
             for user_id in user_ids:
                 S3Utils.delete_user_image_on_s3(user_id)
+            cache.delete_many([f"user_profile_{id}" for id in user_ids])
         cnt, _ = User.objects.filter(id__in=user_ids, is_approved=status).delete()
         if cnt:
             return {"detail": "Success to reject users"}

--- a/wtnt/team/like/service.py
+++ b/wtnt/team/like/service.py
@@ -16,6 +16,7 @@ class LikeService(BaseService):
 
         cache_key = f"team_detail_{team_id}"
         team_cache = cache.get(cache_key)
+        cache_update = False
 
         if team_cache is not None:
             cache_update = True

--- a/wtnt/user/auth/service.py
+++ b/wtnt/user/auth/service.py
@@ -83,7 +83,10 @@ class RegisterService(BaseService):
 
 class RefreshService(BaseService):
     def extract_refresh_token(self):
-        _, access_token = self.request.META.get("HTTP_AUTHORIZATION").split(" ")
+        authorization = self.request.META.get("HTTP_AUTHORIZATION")
+        if authorization is None:
+            raise token_exception.NoTokenInAuthorizationHeaderError()
+        _, access_token = authorization.split(" ")
         try:
             user_id = AccessToken(access_token, verify=False).payload.get("user_id")
         except TokenError:

--- a/wtnt/user/profile/service.py
+++ b/wtnt/user/profile/service.py
@@ -215,9 +215,12 @@ class MyTeamManageService(BaseServiceWithCheckOwnership, BaseServiceWithCheckLea
             team = Team.objects.get(id=team_id)
         except Team.DoesNotExist:
             raise notfound_exception.TeamNotFoundError()
+
         self.check_leader(user_id, team.leader.id)
         S3Utils.delete_team_image_on_s3(team.uuid)
         team.delete()
+
+        cache.delete(f"team_detail_{team_id}")
 
         return {"detail": "Success to delete team"}
 


### PR DESCRIPTION
**## #️⃣ 연관된 이슈** 
> ex) #이슈번호
 <!-- PR Merge 후 이슈 Closed로 바꾸기 -->
- #90 

---

**## 📝 작업 내용**
> ex) 소셜 로그인 연동
- 어드민의 팀/유저 삭제 후 캐시 관리
- 팀장의 팀 삭제 후 캐시 관리
- 리프레시 에러 핸들링

---

**## 📢 참고사항**
> ex) Issue 내용과 달라진 점
- 좋아요 API 캐시 로직 수정
